### PR TITLE
fix: correct cache directory path so repeated requests return HIT

### DIFF
--- a/app/src/Lib/Cache/FileCache.php
+++ b/app/src/Lib/Cache/FileCache.php
@@ -7,7 +7,7 @@ class FileCache {
     private int $defaultTtl;
 
     public function __construct(?string $cacheDir = null, int $defaultTtl = 60) {
-        $this->cacheDir = $cacheDir ?? dirname(__DIR__, 4) . '/cache/http';
+        $this->cacheDir = $cacheDir ?? dirname(__DIR__, 3) . '/cache/http';
         $this->defaultTtl = max(1, $defaultTtl);
     }
 


### PR DESCRIPTION
Corrige la résolution du dossier de cache pour que les fichiers soient bien écrits dans le container PHP.
Résultat: les appels répétés sur la même URL passent de X-Cache: MISS à X-Cache: HIT comme attendu.